### PR TITLE
fix: River water shader now renders with animated flow texture

### DIFF
--- a/src/components/SimpleScene.tsx
+++ b/src/components/SimpleScene.tsx
@@ -1181,6 +1181,11 @@ export function SimpleScene({
         waterfallRef.current.setTimeOfDay(timeOfDay);
       }
 
+      // Update terrain animations (river water shader)
+      if (terrainBuilderRef.current) {
+        terrainBuilderRef.current.updateAnimations(deltaTime);
+      }
+
       // Update interior lights based on time of day (throttled)
       // Night is roughly 0-0.22 and 0.78-1.0
       const isNight = timeOfDay < 0.22 || timeOfDay > 0.78;

--- a/src/lib/terrain/ContinuousTerrainBuilder.ts
+++ b/src/lib/terrain/ContinuousTerrainBuilder.ts
@@ -174,8 +174,9 @@ export class ContinuousTerrainBuilder {
     const vertices: number[] = [];
     const uvs: number[] = [];
     const indices: number[] = [];
-    // Water offset below terrain surface (sits in carved valley)
-    const waterDepthOffset = -0.15;
+    // Water offset above terrain surface (valley floor is already carved down)
+    // Positive offset ensures water renders above the ground mesh
+    const waterDepthOffset = 0.1;
 
     // Calculate total river length for UV mapping
     let totalLength = 0;
@@ -292,13 +293,14 @@ export class ContinuousTerrainBuilder {
       shallowColor: new THREE.Color(0x5da4d4),
       deepColor: new THREE.Color(0x1a5a8a),
       flowSpeed: 0.12,
-      flowDirection: new THREE.Vector2(0, 1), // Flow along river
+      flowDirection: new THREE.Vector2(0, -1), // Flow along river (downstream)
       rippleScale: 6.0,
       rippleStrength: 0.4,
       opacity: 0.85,
     });
 
     const waterMesh = new THREE.Mesh(geometry, this.waterMaterial);
+    waterMesh.renderOrder = 1; // Render after ground mesh to avoid Z-fighting
     group.add(waterMesh);
 
     return group;


### PR DESCRIPTION
## Summary
- Fix river water rendering - was showing as flat blue ground instead of animated flowing water
- Add missing `updateAnimations()` call to update shader time uniform
- Fix water mesh positioning and render order

## Changes
- `src/components/SimpleScene.tsx` - Add terrain animation update in render loop
- `src/lib/terrain/ContinuousTerrainBuilder.ts` - Fix water depth offset and render order

## Test plan
- [x] Run `npm run dev` and verify river shows animated flowing water
- [x] Verify wooden bridges are visible over the river
- [x] Build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)