### PR TITLE
feat: Shrink minions to half size with proportional animations

### DIFF
--- a/src/components/MinionEntity.tsx
+++ b/src/components/MinionEntity.tsx
@@ -14,6 +14,9 @@ interface MinionEntityProps {
   minion: Minion;
 }
 
+// Minion scale factor - controls overall minion size (0.5 = half size)
+const MINION_SCALE = 0.5;
+
 // Goblin color palette
 const GOBLIN_COLORS = {
   skin: '#5a9c4e',
@@ -97,11 +100,11 @@ export function MinionEntity({ minion }: MinionEntityProps) {
   const animateIdle = useCallback((time: number) => {
     if (!groupRef.current) return;
 
-    // Gentle bobbing
-    groupRef.current.position.y = minion.position.y + Math.sin(time * 1.5) * 0.03;
+    // Gentle bobbing (halved for smaller minion)
+    groupRef.current.position.y = minion.position.y + Math.sin(time * 1.5) * 0.015;
 
-    // Subtle body sway
-    groupRef.current.rotation.z = Math.sin(time * 0.8) * 0.02;
+    // Subtle body sway (halved for smaller minion)
+    groupRef.current.rotation.z = Math.sin(time * 0.8) * 0.01;
 
     // Arms at rest, slight movement
     if (leftArmRef.current && rightArmRef.current) {
@@ -121,14 +124,14 @@ export function MinionEntity({ minion }: MinionEntityProps) {
   const animateTraveling = useCallback((time: number) => {
     if (!groupRef.current) return;
 
-    // Bouncy walking motion
+    // Bouncy walking motion (halved for smaller minion)
     const walkCycle = time * 8;
-    const bounce = Math.abs(Math.sin(walkCycle)) * 0.08;
+    const bounce = Math.abs(Math.sin(walkCycle)) * 0.04;
     groupRef.current.position.y = minion.position.y + bounce;
 
-    // Body lean while walking
-    groupRef.current.rotation.z = Math.sin(walkCycle) * 0.08;
-    groupRef.current.rotation.x = 0.1; // Slight forward lean
+    // Body lean while walking (halved for smaller minion)
+    groupRef.current.rotation.z = Math.sin(walkCycle) * 0.04;
+    groupRef.current.rotation.x = 0.05; // Slight forward lean (halved)
 
     // Arm swing
     if (leftArmRef.current && rightArmRef.current) {
@@ -148,8 +151,8 @@ export function MinionEntity({ minion }: MinionEntityProps) {
   const animateWorking = useCallback((time: number) => {
     if (!groupRef.current) return;
 
-    // Focused slight bobbing
-    groupRef.current.position.y = minion.position.y + Math.sin(time * 3) * 0.02;
+    // Focused slight bobbing (halved for smaller minion)
+    groupRef.current.position.y = minion.position.y + Math.sin(time * 3) * 0.01;
 
     // Arms doing work motion
     if (leftArmRef.current && rightArmRef.current) {
@@ -170,8 +173,8 @@ export function MinionEntity({ minion }: MinionEntityProps) {
   const animateStuck = useCallback((time: number) => {
     if (!groupRef.current) return;
 
-    // Frustrated shaking
-    groupRef.current.position.x = minion.position.x + Math.sin(time * 15) * 0.03;
+    // Frustrated shaking (halved for smaller minion)
+    groupRef.current.position.x = minion.position.x + Math.sin(time * 15) * 0.015;
     groupRef.current.position.y = minion.position.y;
 
     // Arms flailing in frustration
@@ -192,12 +195,12 @@ export function MinionEntity({ minion }: MinionEntityProps) {
   const animateReturning = useCallback((time: number) => {
     if (!groupRef.current) return;
 
-    // Happy bouncing
+    // Happy bouncing (halved for smaller minion)
     const bounceCycle = time * 6;
-    groupRef.current.position.y = minion.position.y + Math.abs(Math.sin(bounceCycle)) * 0.15;
+    groupRef.current.position.y = minion.position.y + Math.abs(Math.sin(bounceCycle)) * 0.075;
 
-    // Celebratory body motion
-    groupRef.current.rotation.z = Math.sin(bounceCycle * 0.5) * 0.1;
+    // Celebratory body motion (halved for smaller minion)
+    groupRef.current.rotation.z = Math.sin(bounceCycle * 0.5) * 0.05;
 
     // Arms up in triumph occasionally
     if (leftArmRef.current && rightArmRef.current) {
@@ -343,6 +346,7 @@ export function MinionEntity({ minion }: MinionEntityProps) {
     <group
       ref={groupRef}
       position={[minion.position.x, minion.position.y, minion.position.z]}
+      scale={MINION_SCALE}
       onClick={handleClick}
       onPointerEnter={() => setHovered(true)}
       onPointerLeave={() => setHovered(false)}

--- a/src/lib/minion/animation/locomotion.ts
+++ b/src/lib/minion/animation/locomotion.ts
@@ -23,19 +23,19 @@ export class LocomotionUpdater implements AnimationUpdater {
 
     const walkCycle = state.animTime * 8 * walkSpeed;
 
-    // Body bounce
-    const bounce = Math.abs(Math.sin(walkCycle)) * 0.15 * bounceAmount;
+    // Body bounce (halved for smaller minion)
+    const bounce = Math.abs(Math.sin(walkCycle)) * 0.075 * bounceAmount;
 
-    // Body lean and sway
-    refs.body.rotation.z = Math.sin(walkCycle) * 0.08;
-    refs.body.rotation.x = 0.08; // Forward lean
+    // Body lean and sway (halved for smaller minion)
+    refs.body.rotation.z = Math.sin(walkCycle) * 0.04;
+    refs.body.rotation.x = 0.04; // Forward lean (halved)
 
     // Leg swing (opposite phases)
     refs.leftLeg.rotation.x = Math.sin(walkCycle + Math.PI) * 0.5 * legSwingAmount;
     refs.rightLeg.rotation.x = Math.sin(walkCycle) * 0.5 * legSwingAmount;
 
-    // Head bob
-    refs.head.rotation.z = Math.sin(walkCycle * 0.5) * 0.05;
+    // Head bob (halved for smaller minion)
+    refs.head.rotation.z = Math.sin(walkCycle * 0.5) * 0.025;
 
     // Store bounce for position calculation
     (refs.root as THREE.Group & { _bounce?: number })._bounce = bounce;
@@ -44,13 +44,13 @@ export class LocomotionUpdater implements AnimationUpdater {
   private updateIdle(ctx: AnimationContext): void {
     const { refs, state, modifiers } = ctx;
 
-    // Gentle body bob
-    const idleBob = Math.sin(state.animTime * 1.5) * 0.03;
+    // Gentle body bob (halved for smaller minion)
+    const idleBob = Math.sin(state.animTime * 1.5) * 0.015;
 
-    // Subtle body sway
+    // Subtle body sway (halved for smaller minion)
     refs.body.rotation.z = THREE.MathUtils.lerp(
       refs.body.rotation.z,
-      Math.sin(state.animTime * 0.8) * 0.02,
+      Math.sin(state.animTime * 0.8) * 0.01,
       0.1
     );
     refs.body.rotation.x = THREE.MathUtils.lerp(refs.body.rotation.x, 0, 0.1);

--- a/src/lib/minion/factory.ts
+++ b/src/lib/minion/factory.ts
@@ -10,6 +10,9 @@ import type {
 import { getSpeciesBuilder } from './species';
 import { MinionAnimator } from './animation';
 
+// Minion scale factor - controls overall minion size (0.5 = half size)
+const MINION_SCALE = 0.5;
+
 /**
  * Options for creating a minion
  */
@@ -52,6 +55,9 @@ export function createMinion(options: CreateMinionOptions): MinionInstance {
 
   // Build the minion mesh
   const { mesh, refs } = builder.build(colors);
+
+  // Apply scale to shrink minions to half size
+  mesh.scale.setScalar(MINION_SCALE);
 
   // Create the animator
   const animator = new MinionAnimator(

--- a/src/lib/questSimulation.ts
+++ b/src/lib/questSimulation.ts
@@ -57,8 +57,8 @@ export function useMinionMovement() {
         const targetPos = PHASE_POSITIONS[quest.phase];
         const currentPos = minion.position;
 
-        // Lerp towards target position
-        const lerpFactor = 0.02;
+        // Lerp towards target position (halved for proportional movement with smaller minions)
+        const lerpFactor = 0.01;
         const newX = currentPos.x + (targetPos.x - currentPos.x) * lerpFactor;
         const newY = currentPos.y + (targetPos.y - currentPos.y) * lerpFactor;
         const newZ = currentPos.z + (targetPos.z - currentPos.z) * lerpFactor;


### PR DESCRIPTION
## Summary
- Shrink all minions to 50% of their original size using a centralized `MINION_SCALE` constant
- Halve animation amplitudes (bob, bounce, sway) so animations look proportional to the smaller body
- Halve movement lerp factor so minions don't appear to zip around

## Changes
- `src/lib/minion/factory.ts`: Add `MINION_SCALE = 0.5` and apply to mesh
- `src/lib/minion/animation/locomotion.ts`: Halve all animation amplitudes
- `src/lib/questSimulation.ts`: Halve movement lerp factor (0.02 → 0.01)
- `src/components/MinionEntity.tsx`: Update legacy component for consistency

## Test plan
- [ ] Verify minions render at half size
- [ ] Verify idle/walking animations look proportional
- [ ] Verify movement speed feels natural relative to body size

🤖 Generated with [Claude Code](https://claude.com/claude-code)