### PR TITLE
feat: Add large crystalline golem minion

### DIFF
--- a/.claude/plans/feat-large-crystalline-golem-minion.md
+++ b/.claude/plans/feat-large-crystalline-golem-minion.md
@@ -1,0 +1,383 @@
+# Implementation Plan: Large Crystalline Golem Minion
+
+## Overview
+
+Create a new Golem minion type that is visually distinct from existing minions (Scout, Scribe, Artificer). The Golem is a massive crystalline/rocky creature (5x+ larger) with floating hands, a tiny head on a huge torso, and stump legs. Players can click to enter first-person mode inside the Golem, experiencing heavy stompy camera movement.
+
+### Design Specifications
+- **Size**: 5x+ larger than standard minions
+- **Texture**: Gray/brown rocky base with orange/blue crystal accents
+- **Head**: Tiny sphere with a crystal "eye" (orange/blue glow)
+- **Torso**: Massive, angular, rocky body
+- **Hands**: Large floating rocky hands (following existing floating hand pattern)
+- **Legs**: Simple stumpy pillars
+- **System**: Independent of minion type system (Scout/Scribe/Artificer), follows same pathfinding behavior
+- **First-Person**: Click to enter, heavy bob + screen shake on movement
+
+---
+
+## Phase 1: Type Definitions & Store Integration
+
+### 1.1 Extend Type System (`src/types/game.ts`)
+
+Add Golem as a separate entity type alongside Minion:
+
+```typescript
+// New Golem interface (separate from Minion)
+export interface Golem {
+  id: string;
+  name: string;
+  position: { x: number; y: number; z: number };
+  state: GolemState;
+  targetPosition?: { x: number; y: number; z: number };
+}
+
+export type GolemState = 'idle' | 'traveling' | 'stomping';
+```
+
+**Files to modify:**
+- `src/types/game.ts` - Add Golem interface and GolemState type
+
+### 1.2 Store Integration (`src/store/gameStore.ts`)
+
+Add Golem state management:
+
+```typescript
+// New store slice
+golems: Golem[];
+selectedGolemId: string | null;
+possessedGolemId: string | null; // For first-person mode
+
+// New actions
+addGolem: (golem: Golem) => void;
+removeGolem: (id: string) => void;
+updateGolemPosition: (id: string, position: Position) => void;
+selectGolem: (id: string | null) => void;
+possessGolem: (id: string | null) => void; // Enter/exit first-person
+```
+
+**Files to modify:**
+- `src/store/gameStore.ts` - Add golems slice with actions
+
+---
+
+## Phase 2: Golem Visual Rendering
+
+### 2.1 Create GolemEntity Component (`src/components/GolemEntity.tsx`)
+
+Build the 3D Golem mesh with procedural geometry:
+
+**Body Structure:**
+```
+Scale Factor: ~5x standard minion
+
+Torso (Massive):
+- BoxGeometry or custom angular rock shape
+- Size: ~1.5w x 2.0h x 1.0d (scaled)
+- Material: meshStandardMaterial
+  - color: #5c5247 (gray-brown rock)
+  - roughness: 0.95
+  - metalness: 0.1
+
+Crystal Accents (on torso):
+- Multiple IcosahedronGeometry crystals embedded in surface
+- Colors: #ff6b35 (orange), #4da6ff (blue)
+- emissive with low intensity glow
+- Random rotation for organic placement
+
+Head (Tiny):
+- SphereGeometry, radius ~0.15 (relative to body scale)
+- Positioned high on torso
+- Single crystal "eye":
+  - SphereGeometry inner orb
+  - Glow effect (emissive + PointLight)
+  - Color cycle between orange/blue
+
+Floating Hands (Large):
+- Similar to existing minion hands but 5x scale
+- Rocky texture matching torso
+- Crystal knuckle accents
+- Float offset: ~0.8 units from body sides
+- Gentle bob animation when idle
+
+Stump Legs:
+- CylinderGeometry or BoxGeometry
+- Short, thick pillars
+- Slight taper toward ground
+- No knee articulation needed
+```
+
+**Materials:**
+```typescript
+const rockMaterial = new MeshStandardMaterial({
+  color: 0x5c5247,
+  roughness: 0.95,
+  metalness: 0.1,
+});
+
+const crystalMaterial = new MeshStandardMaterial({
+  color: 0xff6b35, // or 0x4da6ff
+  emissive: 0xff6b35,
+  emissiveIntensity: 0.4,
+  roughness: 0.3,
+  metalness: 0.2,
+});
+```
+
+**Files to create:**
+- `src/components/GolemEntity.tsx` - Main Golem 3D component
+
+### 2.2 Golem Animation System
+
+**Idle Animation:**
+- Minimal sway (it's heavy)
+- Subtle hand float bob
+- Crystal eye slow pulse
+- Occasional "settling" micro-movements
+
+**Traveling Animation:**
+- Heavy stomping motion (legs alternate)
+- Body rock side-to-side
+- Hands swing with momentum
+- Ground impact timing markers (for camera shake sync)
+
+**Selection Indicators:**
+- Large ring at base (scaled appropriately)
+- State indicator above tiny head
+
+**Files to modify:**
+- `src/components/GolemEntity.tsx` - Add animation logic in useFrame
+
+---
+
+## Phase 3: First-Person Golem Mode
+
+### 3.1 Golem First-Person Hands (`src/lib/GolemFirstPersonHands.ts`)
+
+Create viewmodel for Golem's rocky hands:
+
+**Design:**
+```
+Two floating hands visible in first-person view:
+- Left hand: Lower-left of screen
+- Right hand: Lower-right of screen
+
+Hand Geometry:
+- BoxGeometry base (blocky, angular)
+- Additional box segments for fingers (3 chunky fingers + thumb)
+- Crystal accents on knuckles (small icosahedrons)
+
+Materials:
+- Same rock material as third-person body
+- Crystal accents match body crystals
+
+Positioning:
+- Left: (-0.5, -0.5, -0.8)
+- Right: (0.5, -0.5, -0.8)
+- Slight rotation inward (hands facing each other)
+```
+
+**Animation:**
+- Idle: Very subtle float/bob
+- Moving: Heavier swing matching stomp rhythm
+- Simple implementation (no complex effects per user request)
+
+**Files to create:**
+- `src/lib/GolemFirstPersonHands.ts` - Viewmodel hands class
+
+### 3.2 Stompy Camera Controller (`src/lib/camera/GolemCameraController.ts`)
+
+Extend existing camera system for Golem possession:
+
+**Configuration:**
+```typescript
+const GOLEM_CAMERA_CONFIG = {
+  // Eye height scaled to golem size
+  eyeHeight: 8.0, // Much higher than normal (1.6)
+
+  // Movement (same as standard but feels slower due to scale)
+  moveSpeed: 3.0, // Slower than normal (5.0)
+
+  // Stompy effects
+  stompBobIntensity: 0.15, // Exaggerated vertical bob
+  stompBobFrequency: 1.2, // Slower frequency (heavy steps)
+  screenShakeIntensity: 0.02, // Subtle shake on step impact
+  screenShakeDecay: 0.9, // Quick falloff
+
+  // Step timing
+  stepDuration: 0.6, // Seconds per step (slower than human)
+};
+```
+
+**Stomp Animation Logic:**
+```typescript
+// In update loop when moving:
+const stepPhase = (time * stompBobFrequency) % 1;
+
+// Vertical bob follows step cycle
+const bobOffset = Math.sin(stepPhase * Math.PI * 2) * stompBobIntensity;
+
+// Screen shake on step impact (stepPhase near 0 or 0.5)
+if (stepPhase < 0.1 || (stepPhase > 0.45 && stepPhase < 0.55)) {
+  applyScreenShake(screenShakeIntensity);
+}
+
+// Apply to camera
+camera.position.y = baseHeight + bobOffset;
+camera.rotation.z += currentShake.roll;
+camera.rotation.x += currentShake.pitch;
+```
+
+**Files to create:**
+- `src/lib/camera/GolemCameraController.ts` - Stompy camera logic
+
+### 3.3 Possession System Integration
+
+**Click to Enter:**
+1. Player clicks Golem in isometric view
+2. If already selected, second click triggers possession
+3. Camera transitions smoothly to first-person inside Golem
+4. UI updates to show "Exit Golem" option
+5. Golem hands viewmodel renders
+
+**Exit Mechanism:**
+- Press ESC or click "Exit" button
+- Camera transitions back to isometric
+- Golem returns to selectable state
+
+**Files to modify:**
+- `src/components/GolemEntity.tsx` - Add click handler for possession
+- `src/lib/camera/CameraController.ts` - Add golem possession mode
+- `src/store/gameStore.ts` - Track possessedGolemId
+
+---
+
+## Phase 4: Scene Integration
+
+### 4.1 Render Golems in Scene (`src/components/Scene.tsx`)
+
+Add Golem rendering alongside minions:
+
+```tsx
+// In Scene.tsx
+const { golems, possessedGolemId } = useGameStore();
+
+{golems.map((golem) => (
+  <GolemEntity
+    key={golem.id}
+    golem={golem}
+    isPossessed={golem.id === possessedGolemId}
+  />
+))}
+```
+
+**Files to modify:**
+- `src/components/Scene.tsx` - Add GolemEntity rendering
+
+### 4.2 Conditional Viewmodel Rendering
+
+When possessed, render Golem hands instead of wizard staff:
+
+```tsx
+// In first-person render logic
+{possessedGolemId ? (
+  <GolemFirstPersonHands />
+) : (
+  <FirstPersonHands /> // Existing wizard staff
+)}
+```
+
+**Files to modify:**
+- Wherever FirstPersonHands is currently rendered (likely Scene or a dedicated FP component)
+
+---
+
+## Phase 5: Pathfinding & Movement
+
+### 5.1 Golem Navigation
+
+Golems use the same pathfinding system as minions but:
+- Larger collision radius
+- Slower movement speed
+- Same NavGrid system
+
+**Implementation:**
+- Reuse existing Pathfinder class
+- Adjust parameters for Golem scale
+- Movement lerp factor reduced (slower interpolation)
+
+**Files to modify:**
+- `src/lib/questSimulation.ts` or equivalent movement logic - Support Golem movement
+
+---
+
+## Phase 6: UI Integration
+
+### 6.1 Golem Selection UI
+
+Add Golem-specific UI when selected (not possessed):
+
+- Name display
+- State indicator
+- "Enter Golem" button (alternative to double-click)
+
+**Files to modify/create:**
+- `src/components/ui/GolemPanel.tsx` - New panel for Golem info/controls
+
+### 6.2 Possession HUD
+
+Minimal HUD when inside Golem:
+
+- "Exit" button (top-right or ESC hint)
+- Optional: Golem status indicator
+
+**Files to modify:**
+- `src/components/GameLayout.tsx` - Conditional HUD based on possession state
+
+---
+
+## Implementation Order
+
+1. **Phase 1**: Types and store (foundation)
+2. **Phase 2**: GolemEntity visual (get it rendering)
+3. **Phase 4.1**: Scene integration (see it in world)
+4. **Phase 5**: Basic movement (make it walk)
+5. **Phase 3**: First-person mode (enter the golem)
+6. **Phase 4.2**: Viewmodel hands
+7. **Phase 6**: UI polish
+
+---
+
+## Files Summary
+
+### New Files
+- `src/types/game.ts` - Extended (Golem interface)
+- `src/components/GolemEntity.tsx` - Main 3D component
+- `src/lib/GolemFirstPersonHands.ts` - Viewmodel hands
+- `src/lib/camera/GolemCameraController.ts` - Stompy camera
+- `src/components/ui/GolemPanel.tsx` - Selection UI
+
+### Modified Files
+- `src/store/gameStore.ts` - Golem state management
+- `src/components/Scene.tsx` - Render golems
+- `src/lib/camera/CameraController.ts` - Possession mode integration
+- `src/components/GameLayout.tsx` - Possession HUD
+
+---
+
+## Testing Checklist
+
+- [ ] Golem renders in isometric view at correct scale (5x+)
+- [ ] Rocky texture with orange/blue crystal accents visible
+- [ ] Tiny head with glowing crystal eye
+- [ ] Floating hands animate correctly
+- [ ] Click selection works
+- [ ] Double-click (or button) enters first-person
+- [ ] First-person camera at correct height
+- [ ] Stompy bob effect when moving
+- [ ] Screen shake on step impacts
+- [ ] Rocky hands visible in first-person
+- [ ] ESC exits possession mode
+- [ ] Camera transitions smoothly in/out
+- [ ] Golem follows pathfinding (same as minions)
+- [ ] No Z-fighting or visual glitches

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -13,7 +13,7 @@ import { FirstPersonHUD } from './ui/FirstPersonHUD';
 import { InteractionHUD } from './ui/InteractionHUD';
 import { useGameStore } from '@/store/gameStore';
 import { TOWER_FLOORS } from '@/types/game';
-import { useMinionMovement } from '@/lib/questSimulation';
+import { useMinionMovement, useGolemMovement } from '@/lib/questSimulation';
 import { WowIcon } from './ui/WowIcon';
 import { wowTheme } from '@/styles/theme';
 import { initSoundSettings, preloadSounds, playSound } from '@/lib/sounds';
@@ -30,6 +30,8 @@ export function GameLayout() {
   const conversation = useGameStore((state) => state.conversation);
   const exitConversation = useGameStore((state) => state.exitConversation);
   const cameraMode = useGameStore((state) => state.cameraMode);
+  const possessedGolemId = useGameStore((state) => state.possessedGolemId);
+  const possessGolem = useGameStore((state) => state.possessGolem);
 
   // Interaction state for first person mode and isometric mode
   const [interactionMode, setInteractionMode] = useState<InteractionMode>('idle');
@@ -50,6 +52,9 @@ export function GameLayout() {
 
   // Animate minion movement during quests
   useMinionMovement();
+
+  // Animate golem movement toward targets
+  useGolemMovement();
 
   // Poll for project/PR changes every 30 seconds
   useProjectPolling(30000);
@@ -72,12 +77,20 @@ export function GameLayout() {
     default: wowTheme.colors.scout,
   };
 
-  // Handle Escape key to exit conversation
+  // Handle Escape key to exit conversation or golem possession
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    if (event.key === 'Escape' && conversation.active && conversation.phase === 'active') {
-      exitConversation();
+    if (event.key === 'Escape') {
+      // Exit golem possession first
+      if (possessedGolemId) {
+        possessGolem(null);
+        return;
+      }
+      // Then try to exit conversation
+      if (conversation.active && conversation.phase === 'active') {
+        exitConversation();
+      }
     }
-  }, [conversation.active, conversation.phase, exitConversation]);
+  }, [conversation.active, conversation.phase, exitConversation, possessedGolemId, possessGolem]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/components/GolemEntity.tsx
+++ b/src/components/GolemEntity.tsx
@@ -1,0 +1,529 @@
+'use client';
+
+import { useRef, useState, useMemo, useCallback } from 'react';
+import { useFrame, ThreeEvent } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three';
+import type { Golem } from '@/types/game';
+import { useGameStore } from '@/store/gameStore';
+
+interface GolemEntityProps {
+  golem: Golem;
+}
+
+// Golem is 5x larger than minions (minion scale is 0.5, so golem is 2.5)
+const GOLEM_SCALE = 2.5;
+
+// Golem color palette - rocky with crystal accents
+const GOLEM_COLORS = {
+  // Rocky base
+  rockBase: '#5c5247',
+  rockDark: '#4a433b',
+  rockLight: '#6e6459',
+
+  // Crystal accents
+  crystalOrange: '#ff6b35',
+  crystalOrangeGlow: '#ff8855',
+  crystalBlue: '#4da6ff',
+  crystalBlueGlow: '#66b8ff',
+
+  // Eye
+  eyeCore: '#ff6b35',
+  eyeGlow: '#ffaa66',
+};
+
+export function GolemEntity({ golem }: GolemEntityProps) {
+  const groupRef = useRef<THREE.Group>(null);
+  const leftHandRef = useRef<THREE.Group>(null);
+  const rightHandRef = useRef<THREE.Group>(null);
+  const leftLegRef = useRef<THREE.Group>(null);
+  const rightLegRef = useRef<THREE.Group>(null);
+  const eyeRef = useRef<THREE.Mesh>(null);
+  const eyeGlowRef = useRef<THREE.PointLight>(null);
+
+  const [hovered, setHovered] = useState(false);
+
+  const selectedGolemId = useGameStore((state) => state.selectedGolemId);
+  const possessedGolemId = useGameStore((state) => state.possessedGolemId);
+  const setSelectedGolem = useGameStore((state) => state.setSelectedGolem);
+  const possessGolem = useGameStore((state) => state.possessGolem);
+
+  const isSelected = selectedGolemId === golem.id;
+  const isPossessed = possessedGolemId === golem.id;
+
+  // Create rocky geometry with flat shading for angular look
+  const torsoGeometry = useMemo(() => {
+    const geo = new THREE.BoxGeometry(1.2, 1.6, 0.8, 2, 2, 2);
+    // Deterministic pseudo-random displacement for organic rock feel
+    // Using a simple hash function based on vertex index
+    const seededRandom = (seed: number) => {
+      const x = Math.sin(seed * 12.9898 + seed * 78.233) * 43758.5453;
+      return x - Math.floor(x) - 0.5;
+    };
+    const positions = geo.attributes.position;
+    for (let i = 0; i < positions.count; i++) {
+      positions.setX(i, positions.getX(i) + seededRandom(i * 3) * 0.08);
+      positions.setY(i, positions.getY(i) + seededRandom(i * 3 + 1) * 0.08);
+      positions.setZ(i, positions.getZ(i) + seededRandom(i * 3 + 2) * 0.08);
+    }
+    geo.computeVertexNormals();
+    return geo;
+  }, []);
+
+  // Animation: Idle - minimal movement, heavy creature
+  const animateIdle = useCallback((time: number) => {
+    if (!groupRef.current) return;
+
+    // Very subtle breathing motion
+    groupRef.current.position.y = golem.position.y + Math.sin(time * 0.8) * 0.02;
+
+    // Floating hands gentle bob
+    if (leftHandRef.current && rightHandRef.current) {
+      leftHandRef.current.position.y = -0.2 + Math.sin(time * 1.2) * 0.05;
+      rightHandRef.current.position.y = -0.2 + Math.sin(time * 1.2 + Math.PI) * 0.05;
+    }
+
+    // Eye glow pulse
+    if (eyeGlowRef.current) {
+      eyeGlowRef.current.intensity = 0.8 + Math.sin(time * 2) * 0.3;
+    }
+  }, [golem.position.y]);
+
+  // Animation: Traveling - heavy stomping
+  const animateTraveling = useCallback((time: number) => {
+    if (!groupRef.current) return;
+
+    const walkCycle = time * 2; // Slower than minions
+    const stomp = Math.abs(Math.sin(walkCycle)) * 0.08;
+    groupRef.current.position.y = golem.position.y + stomp;
+
+    // Heavy body sway
+    groupRef.current.rotation.z = Math.sin(walkCycle) * 0.03;
+
+    // Leg movement - heavy stomps
+    if (leftLegRef.current && rightLegRef.current) {
+      leftLegRef.current.position.y = -0.7 + Math.max(0, Math.sin(walkCycle)) * 0.15;
+      rightLegRef.current.position.y = -0.7 + Math.max(0, Math.sin(walkCycle + Math.PI)) * 0.15;
+    }
+
+    // Floating hands swing with momentum
+    if (leftHandRef.current && rightHandRef.current) {
+      leftHandRef.current.position.y = -0.2 + Math.sin(walkCycle) * 0.1;
+      leftHandRef.current.position.z = 0.1 + Math.sin(walkCycle) * 0.15;
+      rightHandRef.current.position.y = -0.2 + Math.sin(walkCycle + Math.PI) * 0.1;
+      rightHandRef.current.position.z = 0.1 + Math.sin(walkCycle + Math.PI) * 0.15;
+    }
+
+    // Eye glow intensifies
+    if (eyeGlowRef.current) {
+      eyeGlowRef.current.intensity = 1.2 + Math.sin(time * 3) * 0.2;
+    }
+  }, [golem.position.y]);
+
+  // Animation: Stomping (special action state)
+  const animateStomping = useCallback((time: number) => {
+    if (!groupRef.current) return;
+
+    // Ground pound motion
+    const stompCycle = time * 4;
+    const pound = Math.abs(Math.sin(stompCycle)) * 0.15;
+    groupRef.current.position.y = golem.position.y + pound;
+
+    // Hands slam down
+    if (leftHandRef.current && rightHandRef.current) {
+      const armSlam = Math.sin(stompCycle) > 0 ? -0.3 : 0.1;
+      leftHandRef.current.position.y = armSlam;
+      rightHandRef.current.position.y = armSlam;
+    }
+
+    // Eye flares
+    if (eyeGlowRef.current) {
+      eyeGlowRef.current.intensity = 1.5 + Math.abs(Math.sin(stompCycle)) * 0.5;
+    }
+  }, [golem.position.y]);
+
+  useFrame((state) => {
+    if (!groupRef.current || isPossessed) return;
+
+    const time = state.clock.elapsedTime;
+
+    switch (golem.state) {
+      case 'idle':
+        animateIdle(time);
+        break;
+      case 'traveling':
+        animateTraveling(time);
+        break;
+      case 'stomping':
+        animateStomping(time);
+        break;
+    }
+
+    // Eye color cycling (subtle shift between orange and blue)
+    if (eyeRef.current) {
+      const colorShift = (Math.sin(time * 0.5) + 1) / 2;
+      const color = new THREE.Color(GOLEM_COLORS.crystalOrange).lerp(
+        new THREE.Color(GOLEM_COLORS.crystalBlue),
+        colorShift * 0.3
+      );
+      (eyeRef.current.material as THREE.MeshStandardMaterial).emissive = color;
+    }
+  });
+
+  const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+
+    if (isSelected) {
+      // Second click on selected golem - enter possession mode
+      possessGolem(golem.id);
+    } else {
+      // First click - select
+      setSelectedGolem(golem.id);
+    }
+  };
+
+  // Don't render if possessed (will be handled by first-person view)
+  if (isPossessed) {
+    return null;
+  }
+
+  return (
+    <group
+      ref={groupRef}
+      position={[golem.position.x, golem.position.y, golem.position.z]}
+      scale={GOLEM_SCALE}
+      onClick={handleClick}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+    >
+      {/* === STUMP LEGS === */}
+      {/* Left Leg */}
+      <group ref={leftLegRef} position={[0.35, -0.7, 0]}>
+        <mesh castShadow>
+          <cylinderGeometry args={[0.25, 0.3, 0.5, 6]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockBase}
+            roughness={0.95}
+            metalness={0.1}
+            flatShading
+          />
+        </mesh>
+        {/* Crystal accent on leg */}
+        <mesh castShadow position={[0.15, 0.1, 0.1]} rotation={[0.3, 0.5, 0]}>
+          <octahedronGeometry args={[0.08, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalBlue}
+            emissive={GOLEM_COLORS.crystalBlue}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+            metalness={0.2}
+          />
+        </mesh>
+      </group>
+
+      {/* Right Leg */}
+      <group ref={rightLegRef} position={[-0.35, -0.7, 0]}>
+        <mesh castShadow>
+          <cylinderGeometry args={[0.25, 0.3, 0.5, 6]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockBase}
+            roughness={0.95}
+            metalness={0.1}
+            flatShading
+          />
+        </mesh>
+        {/* Crystal accent on leg */}
+        <mesh castShadow position={[-0.15, 0.15, 0.08]} rotation={[-0.2, -0.3, 0]}>
+          <octahedronGeometry args={[0.06, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalOrange}
+            emissive={GOLEM_COLORS.crystalOrange}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+            metalness={0.2}
+          />
+        </mesh>
+      </group>
+
+      {/* === MASSIVE TORSO === */}
+      <group position={[0, 0.4, 0]}>
+        {/* Main body - rocky box */}
+        <mesh castShadow geometry={torsoGeometry}>
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockBase}
+            roughness={0.95}
+            metalness={0.1}
+            flatShading
+          />
+        </mesh>
+
+        {/* Rocky protrusions for texture */}
+        <mesh castShadow position={[0.5, 0.3, 0.3]} rotation={[0.2, 0.5, 0.3]}>
+          <boxGeometry args={[0.3, 0.25, 0.2]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[-0.45, -0.2, 0.35]} rotation={[-0.1, -0.3, 0.1]}>
+          <boxGeometry args={[0.25, 0.3, 0.2]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockLight} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[0.3, -0.5, 0.2]} rotation={[0.1, 0.2, -0.2]}>
+          <boxGeometry args={[0.2, 0.2, 0.15]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+
+        {/* Crystal clusters on torso */}
+        {/* Large orange crystal cluster */}
+        <group position={[0.4, 0.5, 0.35]} rotation={[0.3, 0.4, 0.2]}>
+          <mesh castShadow>
+            <octahedronGeometry args={[0.15, 0]} />
+            <meshStandardMaterial
+              color={GOLEM_COLORS.crystalOrange}
+              emissive={GOLEM_COLORS.crystalOrange}
+              emissiveIntensity={0.4}
+              roughness={0.3}
+              metalness={0.2}
+            />
+          </mesh>
+          <mesh castShadow position={[0.08, -0.05, 0.05]} rotation={[0.5, 0.3, 0]}>
+            <octahedronGeometry args={[0.08, 0]} />
+            <meshStandardMaterial
+              color={GOLEM_COLORS.crystalOrangeGlow}
+              emissive={GOLEM_COLORS.crystalOrangeGlow}
+              emissiveIntensity={0.3}
+              roughness={0.3}
+            />
+          </mesh>
+        </group>
+
+        {/* Blue crystal cluster */}
+        <group position={[-0.35, 0.2, 0.4]} rotation={[-0.2, -0.3, 0.1]}>
+          <mesh castShadow>
+            <octahedronGeometry args={[0.12, 0]} />
+            <meshStandardMaterial
+              color={GOLEM_COLORS.crystalBlue}
+              emissive={GOLEM_COLORS.crystalBlue}
+              emissiveIntensity={0.4}
+              roughness={0.3}
+              metalness={0.2}
+            />
+          </mesh>
+          <mesh castShadow position={[-0.06, 0.08, 0.02]} rotation={[0.2, -0.4, 0.3]}>
+            <octahedronGeometry args={[0.07, 0]} />
+            <meshStandardMaterial
+              color={GOLEM_COLORS.crystalBlueGlow}
+              emissive={GOLEM_COLORS.crystalBlueGlow}
+              emissiveIntensity={0.3}
+              roughness={0.3}
+            />
+          </mesh>
+        </group>
+
+        {/* Small crystal accents scattered */}
+        <mesh castShadow position={[0.1, -0.6, 0.38]} rotation={[0.5, 0, 0.2]}>
+          <octahedronGeometry args={[0.06, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalBlue}
+            emissive={GOLEM_COLORS.crystalBlue}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+          />
+        </mesh>
+        <mesh castShadow position={[-0.2, 0.6, 0.3]} rotation={[-0.3, 0.4, 0]}>
+          <octahedronGeometry args={[0.05, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalOrange}
+            emissive={GOLEM_COLORS.crystalOrange}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+          />
+        </mesh>
+      </group>
+
+      {/* === TINY HEAD === */}
+      <group position={[0, 1.4, 0.1]}>
+        {/* Small rocky head */}
+        <mesh castShadow>
+          <sphereGeometry args={[0.15, 5, 4]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockDark}
+            roughness={0.9}
+            flatShading
+          />
+        </mesh>
+
+        {/* Crystal eye - the soul of the golem */}
+        <mesh
+          ref={eyeRef}
+          position={[0, 0, 0.12]}
+        >
+          <sphereGeometry args={[0.08, 8, 6]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.eyeCore}
+            emissive={GOLEM_COLORS.eyeCore}
+            emissiveIntensity={0.8}
+            roughness={0.2}
+            metalness={0.3}
+          />
+        </mesh>
+
+        {/* Eye glow light */}
+        <pointLight
+          ref={eyeGlowRef}
+          position={[0, 0, 0.2]}
+          color={GOLEM_COLORS.eyeGlow}
+          intensity={0.8}
+          distance={2}
+          decay={2}
+        />
+
+        {/* Small crystal horn/protrusion */}
+        <mesh castShadow position={[0.08, 0.1, 0]} rotation={[0, 0, -0.3]}>
+          <coneGeometry args={[0.03, 0.1, 4]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalOrange}
+            emissive={GOLEM_COLORS.crystalOrange}
+            emissiveIntensity={0.2}
+            roughness={0.4}
+          />
+        </mesh>
+      </group>
+
+      {/* === FLOATING HANDS === */}
+      {/* Left Hand */}
+      <group ref={leftHandRef} position={[0.9, -0.2, 0.1]}>
+        {/* Main hand mass */}
+        <mesh castShadow>
+          <boxGeometry args={[0.35, 0.25, 0.2]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockBase}
+            roughness={0.95}
+            flatShading
+          />
+        </mesh>
+        {/* Fingers - chunky stone digits */}
+        <mesh castShadow position={[0.15, -0.05, 0.08]}>
+          <boxGeometry args={[0.08, 0.2, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[0.05, -0.08, 0.08]}>
+          <boxGeometry args={[0.08, 0.22, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockBase} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[-0.05, -0.06, 0.08]}>
+          <boxGeometry args={[0.08, 0.18, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+        {/* Thumb */}
+        <mesh castShadow position={[-0.15, 0.02, 0.08]} rotation={[0, 0, 0.5]}>
+          <boxGeometry args={[0.07, 0.12, 0.07]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockLight} roughness={0.95} flatShading />
+        </mesh>
+        {/* Crystal knuckle accent */}
+        <mesh castShadow position={[0.05, 0.1, 0.12]} rotation={[0.3, 0.2, 0]}>
+          <octahedronGeometry args={[0.05, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalBlue}
+            emissive={GOLEM_COLORS.crystalBlue}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+          />
+        </mesh>
+      </group>
+
+      {/* Right Hand */}
+      <group ref={rightHandRef} position={[-0.9, -0.2, 0.1]}>
+        {/* Main hand mass */}
+        <mesh castShadow>
+          <boxGeometry args={[0.35, 0.25, 0.2]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.rockBase}
+            roughness={0.95}
+            flatShading
+          />
+        </mesh>
+        {/* Fingers */}
+        <mesh castShadow position={[-0.15, -0.05, 0.08]}>
+          <boxGeometry args={[0.08, 0.2, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[-0.05, -0.08, 0.08]}>
+          <boxGeometry args={[0.08, 0.22, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockBase} roughness={0.95} flatShading />
+        </mesh>
+        <mesh castShadow position={[0.05, -0.06, 0.08]}>
+          <boxGeometry args={[0.08, 0.18, 0.08]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockDark} roughness={0.95} flatShading />
+        </mesh>
+        {/* Thumb */}
+        <mesh castShadow position={[0.15, 0.02, 0.08]} rotation={[0, 0, -0.5]}>
+          <boxGeometry args={[0.07, 0.12, 0.07]} />
+          <meshStandardMaterial color={GOLEM_COLORS.rockLight} roughness={0.95} flatShading />
+        </mesh>
+        {/* Crystal knuckle accent */}
+        <mesh castShadow position={[-0.05, 0.1, 0.12]} rotation={[-0.2, -0.3, 0]}>
+          <octahedronGeometry args={[0.05, 0]} />
+          <meshStandardMaterial
+            color={GOLEM_COLORS.crystalOrange}
+            emissive={GOLEM_COLORS.crystalOrange}
+            emissiveIntensity={0.3}
+            roughness={0.3}
+          />
+        </mesh>
+      </group>
+
+      {/* Selection ring - larger for golem */}
+      {(isSelected || hovered) && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.9, 0]}>
+          <ringGeometry args={[0.8, 1.0, 32]} />
+          <meshBasicMaterial
+            color={isSelected ? '#fbbf24' : '#ffffff'}
+            transparent
+            opacity={0.6}
+          />
+        </mesh>
+      )}
+
+      {/* State indicator */}
+      <GolemStateIndicator state={golem.state} />
+
+      {/* Name label on hover */}
+      {(hovered || isSelected) && (
+        <Html
+          position={[0, 1.8, 0]}
+          center
+          style={{
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <div className="bg-gray-900/90 text-white px-2 py-1 rounded text-sm font-medium">
+            {golem.name}
+            <span className="text-gray-400 ml-1 text-xs">(Golem)</span>
+          </div>
+          {isSelected && (
+            <div className="text-xs text-amber-400 text-center mt-1">
+              Click again to enter
+            </div>
+          )}
+        </Html>
+      )}
+    </group>
+  );
+}
+
+function GolemStateIndicator({ state }: { state: Golem['state'] }) {
+  if (state === 'idle') return null;
+
+  const colors: Record<Golem['state'], string> = {
+    idle: '#6b7280',
+    traveling: '#3b82f6',
+    stomping: '#ef4444',
+  };
+
+  return (
+    <mesh position={[0, 1.7, 0]}>
+      <sphereGeometry args={[0.1, 6, 5]} />
+      <meshBasicMaterial color={colors[state]} />
+    </mesh>
+  );
+}

--- a/src/components/SimpleScene.tsx
+++ b/src/components/SimpleScene.tsx
@@ -26,6 +26,9 @@ import {
   type ProjectBuildingMesh,
 } from '@/lib/projectBuildings';
 import { FirstPersonHands } from '@/lib/FirstPersonHands';
+import { GolemFirstPersonHands } from '@/lib/GolemFirstPersonHands';
+import { GolemCameraController } from '@/lib/camera';
+import { createGolem, updateGolemAnimation, type GolemInstance } from '@/lib/golem';
 import { StaffInteractionController } from '@/lib/interaction';
 import type { ThrownEntity } from '@/lib/interaction/StaffInteractionController';
 import type { InteractionMode, MenuOption, DrawnFoundation } from '@/types/interaction';
@@ -71,6 +74,14 @@ interface MinionSceneData {
   elevatedCurrentPoint: ElevatedNavPoint | null;
   scaffoldWorkTimer: number; // Time until next work pause
   scaffoldIsWorking: boolean; // Currently doing work animation
+}
+
+// Golem scene data for vanilla Three.js rendering
+interface GolemSceneData {
+  golemId: string;
+  instance: GolemInstance;
+  currentPosition: THREE.Vector3;
+  state: 'idle' | 'traveling' | 'stomping';
 }
 
 // Wildlife (squirrels, rabbits) data
@@ -150,6 +161,7 @@ export function SimpleScene({
   const controlsRef = useRef<OrbitControls | null>(null);
   const cameraControllerRef = useRef<CameraController | null>(null);
   const minionsRef = useRef<Map<string, MinionSceneData>>(new Map());
+  const golemsSceneRef = useRef<Map<string, GolemSceneData>>(new Map());
   const projectBuildingsRef = useRef<Map<string, ProjectBuildingMesh>>(new Map());
   const elevatedSurfaceRegistryRef = useRef<ElevatedSurfaceRegistry>(new ElevatedSurfaceRegistry());
   const elevatedPathfinderRef = useRef<ElevatedPathfinder | null>(null);
@@ -179,6 +191,11 @@ export function SimpleScene({
   const interactionControllerRef = useRef<StaffInteractionController | null>(null);
   const firstPersonHandsRef = useRef<FirstPersonHands | null>(null);
   const isFirstPersonRef = useRef<boolean>(false);
+  // Golem possession mode refs
+  const golemHandsRef = useRef<GolemFirstPersonHands | null>(null);
+  const golemCameraControllerRef = useRef<GolemCameraController | null>(null);
+  const isGolemPossessedRef = useRef<boolean>(false);
+  const golemMeshRef = useRef<THREE.Group | null>(null);
   const outlineEffectRef = useRef<OutlineEffect | null>(null);
   const lastDeltaUpdateRef = useRef<number>(0);
   const thrownMinionsRef = useRef<Map<string, ThrownMinionState>>(new Map());
@@ -200,6 +217,16 @@ export function SimpleScene({
   const exitConversation = useGameStore((state) => state.exitConversation);
   const setConversationPhase = useGameStore((state) => state.setConversationPhase);
   const transitionToMinion = useGameStore((state) => state.transitionToMinion);
+
+  // Golem state
+  const golems = useGameStore((state) => state.golems);
+  const golemsDataRef = useRef(golems);
+  golemsDataRef.current = golems;
+  const possessedGolemId = useGameStore((state) => state.possessedGolemId);
+  const possessedGolemIdRef = useRef(possessedGolemId);
+  possessedGolemIdRef.current = possessedGolemId;
+  const possessGolem = useGameStore((state) => state.possessGolem);
+  const addGolem = useGameStore((state) => state.addGolem);
 
   // Project store
   const { projects, scanProjects } = useProjectStore();
@@ -973,6 +1000,14 @@ export function SimpleScene({
           });
         }
       },
+      onSpawnGolem: (position) => {
+        // Summon a new golem at the targeted ground position
+        const golemNames = ['Craghorn', 'Boulderfist', 'Stoneguard', 'Rockmaw', 'Graniteclaw'];
+        const randomName = golemNames[Math.floor(Math.random() * golemNames.length)];
+        const golem = addGolem(randomName);
+        // Update position to where user clicked
+        useGameStore.getState().updateGolemPosition(golem.id, position);
+      },
     });
 
     // Expose execute action callback to parent
@@ -1037,13 +1072,21 @@ export function SimpleScene({
 
       // Forward input to first person controller when in first person mode
       if (isFirstPersonRef.current) {
-        fpController.handleKeyDown(event);
+        if (isGolemPossessedRef.current && golemCameraControllerRef.current) {
+          golemCameraControllerRef.current.handleKeyDown(event);
+        } else {
+          fpController.handleKeyDown(event);
+        }
       }
     }
 
     function handleKeyUp(event: KeyboardEvent) {
       if (isFirstPersonRef.current) {
-        fpController.handleKeyUp(event);
+        if (isGolemPossessedRef.current && golemCameraControllerRef.current) {
+          golemCameraControllerRef.current.handleKeyUp(event);
+        } else {
+          fpController.handleKeyUp(event);
+        }
       }
     }
 
@@ -1065,11 +1108,18 @@ export function SimpleScene({
           }
         } else {
           // Normal camera movement
-          fpController.handleMouseMove(event);
-
-          // Apply sway to hands
-          if (firstPersonHandsRef.current) {
-            firstPersonHandsRef.current.setSway(event.movementX, event.movementY);
+          if (isGolemPossessedRef.current && golemCameraControllerRef.current) {
+            golemCameraControllerRef.current.handleMouseMove(event);
+            // Apply sway to golem hands
+            if (golemHandsRef.current) {
+              golemHandsRef.current.setSway(event.movementX, event.movementY);
+            }
+          } else {
+            fpController.handleMouseMove(event);
+            // Apply sway to wizard staff hands
+            if (firstPersonHandsRef.current) {
+              firstPersonHandsRef.current.setSway(event.movementX, event.movementY);
+            }
           }
 
           // Forward to interaction controller
@@ -1515,12 +1565,26 @@ export function SimpleScene({
 
         wasWizardFlyingRef.current = isFlying;
 
-        // Update first person hands animation
-        if (firstPersonHandsRef.current) {
+        // Update first person hands animation (wizard staff)
+        if (firstPersonHandsRef.current && !isGolemPossessedRef.current) {
           const isMoving = fpController.isMoving();
           const speed = fpController.getVelocity().length() / 5; // Normalize to 0-1ish
           firstPersonHandsRef.current.setBobbing(isMoving, speed);
           firstPersonHandsRef.current.update(deltaTime, elapsedTime);
+        }
+
+        // Update golem camera and hands when possessed
+        if (isGolemPossessedRef.current && golemCameraControllerRef.current) {
+          golemCameraControllerRef.current.update(deltaTime, elapsedTime);
+
+          // Update golem hands animation
+          if (golemHandsRef.current) {
+            const isMoving = golemCameraControllerRef.current.isMoving();
+            const stepPhase = golemCameraControllerRef.current.getStepPhase();
+            golemHandsRef.current.setBobbing(isMoving, 1);
+            golemHandsRef.current.setStepPhase(stepPhase);
+            golemHandsRef.current.update(deltaTime, elapsedTime);
+          }
         }
 
         // Update interaction controller (targeting, force grab physics, etc.)
@@ -2039,6 +2103,19 @@ export function SimpleScene({
         }
       });
 
+      // Update golem animations
+      golemsSceneRef.current.forEach((data) => {
+        // Skip possessed golem (handled by golem camera controller)
+        if (possessedGolemIdRef.current === data.golemId) return;
+
+        updateGolemAnimation(
+          data.instance,
+          data.state,
+          elapsedTime,
+          data.currentPosition.y
+        );
+      });
+
       // Update wall culler with character-inside state - DISABLED
       // if (wallCullerRef.current) {
       //   wallCullerRef.current.setCharacterInside(anyCharacterInside);
@@ -2391,6 +2468,52 @@ export function SimpleScene({
     });
   }, [hasHydrated, minions, selectedMinionId]);
 
+  // Sync golems with store
+  useEffect(() => {
+    if (!hasHydrated || !sceneRef.current || !terrainBuilderRef.current) return;
+
+    const scene = sceneRef.current;
+    const terrain = terrainBuilderRef.current;
+    const currentGolems = golemsSceneRef.current;
+
+    // Add new golems
+    golems.forEach((golem) => {
+      if (!currentGolems.has(golem.id)) {
+        const instance = createGolem();
+
+        // Use golem's stored position
+        const startY = terrain.getHeightAt(golem.position.x, golem.position.z) + 0.1;
+        instance.mesh.position.set(golem.position.x, startY, golem.position.z);
+        instance.mesh.userData.golemId = golem.id;
+
+        scene.add(instance.mesh);
+
+        currentGolems.set(golem.id, {
+          golemId: golem.id,
+          instance,
+          currentPosition: new THREE.Vector3(golem.position.x, startY, golem.position.z),
+          state: golem.state,
+        });
+      } else {
+        // Update existing golem position if it changed in store
+        const data = currentGolems.get(golem.id)!;
+        const targetY = terrain.getHeightAt(golem.position.x, golem.position.z) + 0.1;
+        data.currentPosition.set(golem.position.x, targetY, golem.position.z);
+        data.instance.mesh.position.copy(data.currentPosition);
+        data.state = golem.state;
+      }
+    });
+
+    // Remove golems that no longer exist
+    currentGolems.forEach((data, golemId) => {
+      if (!golems.find((g) => g.id === golemId)) {
+        scene.remove(data.instance.mesh);
+        data.instance.dispose();
+        currentGolems.delete(golemId);
+      }
+    });
+  }, [hasHydrated, golems]);
+
   // Handle conversation phase changes
   useEffect(() => {
     if (!cameraControllerRef.current) return;
@@ -2644,6 +2767,92 @@ export function SimpleScene({
   const handleLeaveConversation = useCallback(() => {
     exitConversation();
   }, [exitConversation]);
+
+  // Handle golem possession mode changes
+  useEffect(() => {
+    if (!rendererRef.current || !cameraControllerRef.current) return;
+
+    const renderer = rendererRef.current;
+    const perspCamera = cameraControllerRef.current.getPerspCamera();
+
+    if (possessedGolemId && !isGolemPossessedRef.current) {
+      // Enter golem possession mode
+      const golem = golemsDataRef.current.find((g) => g.id === possessedGolemId);
+      if (!golem) return;
+
+      // Create golem camera controller if needed
+      if (!golemCameraControllerRef.current) {
+        golemCameraControllerRef.current = new GolemCameraController();
+      }
+
+      // Create golem hands if needed
+      if (!golemHandsRef.current) {
+        const golemHands = new GolemFirstPersonHands();
+        golemHands.setVisible(false);
+        perspCamera.add(golemHands.getObject());
+        golemHandsRef.current = golemHands;
+      }
+
+      // Set up golem camera at golem position
+      const golemPos = new THREE.Vector3(golem.position.x, golem.position.y, golem.position.z);
+      golemCameraControllerRef.current.setPosition(golemPos);
+      golemCameraControllerRef.current.setCamera(perspCamera);
+
+      // Enter first person mode via camera controller
+      cameraControllerRef.current.enterFirstPerson(golemPos, 0);
+      isGolemPossessedRef.current = true;
+      isFirstPersonRef.current = true; // Reuse first person flag for input handling
+
+      // Hide wizard staff hands, show golem hands
+      if (firstPersonHandsRef.current) {
+        firstPersonHandsRef.current.setVisible(false);
+      }
+      if (golemHandsRef.current) {
+        golemHandsRef.current.setVisible(true);
+      }
+
+      // Hide golem mesh (we're inside it)
+      if (golemMeshRef.current) {
+        golemMeshRef.current.visible = false;
+      }
+
+      // Request pointer lock
+      renderer.domElement.requestPointerLock();
+
+    } else if (!possessedGolemId && isGolemPossessedRef.current) {
+      // Exit golem possession mode
+      if (document.pointerLockElement === renderer.domElement) {
+        document.exitPointerLock();
+      }
+
+      // Get final position from golem camera
+      if (golemCameraControllerRef.current) {
+        const finalPos = golemCameraControllerRef.current.getGroundPosition();
+        // Update golem position in store
+        const store = useGameStore.getState();
+        store.updateGolemPosition(possessedGolemId || '', {
+          x: finalPos.x,
+          y: finalPos.y,
+          z: finalPos.z,
+        });
+      }
+
+      // Hide golem hands, show wizard staff if in normal first person
+      if (golemHandsRef.current) {
+        golemHandsRef.current.setVisible(false);
+      }
+
+      // Show golem mesh again
+      if (golemMeshRef.current) {
+        golemMeshRef.current.visible = true;
+      }
+
+      // Exit first person camera mode
+      cameraControllerRef.current.exitFirstPerson();
+      isGolemPossessedRef.current = false;
+      isFirstPersonRef.current = false;
+    }
+  }, [possessedGolemId]);
 
   return <div ref={containerRef} style={{ width: '100%', height: '100%', cursor: 'pointer' }} />;
 }

--- a/src/components/VillageScene.tsx
+++ b/src/components/VillageScene.tsx
@@ -8,6 +8,7 @@ import { useProjectStore } from '@/store/projectStore';
 import { useGameStore } from '@/store/gameStore';
 import { Building } from './Building';
 import { MinionEntity } from './MinionEntity';
+import { GolemEntity } from './GolemEntity';
 import { VillageGround } from './VillageGround';
 
 interface VillageSceneProps {
@@ -22,7 +23,7 @@ export function VillageScene({
   selectedProjectId,
 }: VillageSceneProps) {
   const { projects, scanProjects, isScanning } = useProjectStore();
-  const { minions } = useGameStore();
+  const { minions, golems } = useGameStore();
   const [cameraDistance, setCameraDistance] = useState(20);
 
   // Initial scan and polling
@@ -170,6 +171,11 @@ export function VillageScene({
           key={minion.id}
           minion={{ ...minion, position: { x: position[0], y: position[1], z: position[2] } }}
         />
+      ))}
+
+      {/* Golems */}
+      {golems.map((golem) => (
+        <GolemEntity key={golem.id} golem={golem} />
       ))}
 
       {/* Loading indicator */}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,5 @@ export { Scene } from './Scene';
 export { Tower } from './Tower';
 export { Ground } from './Ground';
 export { MinionEntity } from './MinionEntity';
+export { GolemEntity } from './GolemEntity';
 export { GameLayout } from './GameLayout';

--- a/src/components/ui/FirstPersonHUD.tsx
+++ b/src/components/ui/FirstPersonHUD.tsx
@@ -1,17 +1,32 @@
 'use client';
 
+import { useGameStore } from '@/store/gameStore';
+
 interface FirstPersonHUDProps {
   visible: boolean;
 }
 
 export function FirstPersonHUD({ visible }: FirstPersonHUDProps) {
+  const possessedGolemId = useGameStore((state) => state.possessedGolemId);
+  const golems = useGameStore((state) => state.golems);
+  const possessGolem = useGameStore((state) => state.possessGolem);
+
   if (!visible) return null;
+
+  const isGolemMode = !!possessedGolemId;
+  const possessedGolem = golems.find((g) => g.id === possessedGolemId);
 
   return (
     <div className="fixed inset-0 pointer-events-none z-40">
-      {/* Crosshair - subtle dot */}
+      {/* Crosshair - larger for golem mode */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-        <div className="w-1.5 h-1.5 bg-white/40 rounded-full shadow-sm" />
+        {isGolemMode ? (
+          // Golem crosshair - chunky square
+          <div className="w-3 h-3 border-2 border-orange-400/60 rotate-45 shadow-lg" />
+        ) : (
+          // Wizard crosshair - subtle dot
+          <div className="w-1.5 h-1.5 bg-white/40 rounded-full shadow-sm" />
+        )}
       </div>
 
       {/* Controls hint - auto-fades via CSS animation */}
@@ -21,34 +36,64 @@ export function FirstPersonHUD({ visible }: FirstPersonHUDProps) {
           animation: 'fadeOutDelayed 5s forwards',
         }}
       >
-        <div className="bg-black/50 backdrop-blur-sm rounded-lg px-4 py-2 text-white/80 text-sm flex items-center gap-4">
+        <div className={`backdrop-blur-sm rounded-lg px-4 py-2 text-sm flex items-center gap-4 ${
+          isGolemMode ? 'bg-orange-900/50 text-orange-100/80' : 'bg-black/50 text-white/80'
+        }`}>
           <span className="flex items-center gap-1">
-            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">W</kbd>
-            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">A</kbd>
-            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">S</kbd>
-            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">D</kbd>
-            <span className="ml-1 text-white/60">Move</span>
+            <kbd className={`px-1.5 py-0.5 rounded text-xs ${isGolemMode ? 'bg-orange-400/20' : 'bg-white/10'}`}>W</kbd>
+            <kbd className={`px-1.5 py-0.5 rounded text-xs ${isGolemMode ? 'bg-orange-400/20' : 'bg-white/10'}`}>A</kbd>
+            <kbd className={`px-1.5 py-0.5 rounded text-xs ${isGolemMode ? 'bg-orange-400/20' : 'bg-white/10'}`}>S</kbd>
+            <kbd className={`px-1.5 py-0.5 rounded text-xs ${isGolemMode ? 'bg-orange-400/20' : 'bg-white/10'}`}>D</kbd>
+            <span className={`ml-1 ${isGolemMode ? 'text-orange-200/60' : 'text-white/60'}`}>
+              {isGolemMode ? 'Stomp' : 'Move'}
+            </span>
           </span>
-          <span className="text-white/40">|</span>
+          <span className={isGolemMode ? 'text-orange-400/40' : 'text-white/40'}>|</span>
           <span className="flex items-center gap-1">
-            <span className="text-white/60">Mouse</span>
+            <span className={isGolemMode ? 'text-orange-200/60' : 'text-white/60'}>Mouse</span>
             <span className="ml-1">Look</span>
           </span>
-          <span className="text-white/40">|</span>
+          <span className={isGolemMode ? 'text-orange-400/40' : 'text-white/40'}>|</span>
           <span className="flex items-center gap-1">
-            <kbd className="px-1.5 py-0.5 bg-white/10 rounded text-xs">Tab</kbd>
-            <span className="ml-1 text-white/60">Exit</span>
+            <kbd className={`px-1.5 py-0.5 rounded text-xs ${isGolemMode ? 'bg-orange-400/20' : 'bg-white/10'}`}>ESC</kbd>
+            <span className={`ml-1 ${isGolemMode ? 'text-orange-200/60' : 'text-white/60'}`}>
+              {isGolemMode ? 'Exit Golem' : 'Exit'}
+            </span>
           </span>
         </div>
       </div>
 
       {/* Mode indicator - top right */}
       <div className="absolute top-4 right-4">
-        <div className="bg-black/30 backdrop-blur-sm rounded px-3 py-1.5 text-white/60 text-xs uppercase tracking-wider flex items-center gap-2">
-          <div className="w-2 h-2 bg-amber-400 rounded-full animate-pulse" />
-          First Person
-        </div>
+        {isGolemMode ? (
+          // Golem mode indicator
+          <div className="bg-orange-900/40 backdrop-blur-sm rounded px-3 py-1.5 text-orange-200/80 text-xs uppercase tracking-wider flex items-center gap-2">
+            <div className="w-2 h-2 bg-orange-400 rounded-sm animate-pulse" />
+            <span className="font-bold">{possessedGolem?.name || 'Golem'}</span>
+          </div>
+        ) : (
+          // Wizard mode indicator
+          <div className="bg-black/30 backdrop-blur-sm rounded px-3 py-1.5 text-white/60 text-xs uppercase tracking-wider flex items-center gap-2">
+            <div className="w-2 h-2 bg-amber-400 rounded-full animate-pulse" />
+            First Person
+          </div>
+        )}
       </div>
+
+      {/* Golem-specific exit button (pointer events enabled) */}
+      {isGolemMode && (
+        <div className="absolute bottom-4 right-4 pointer-events-auto">
+          <button
+            onClick={() => possessGolem(null)}
+            className="bg-orange-800/60 hover:bg-orange-700/60 backdrop-blur-sm rounded-lg px-4 py-2 text-orange-100 text-sm font-medium transition-colors flex items-center gap-2"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+            Exit Golem
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/GolemFirstPersonHands.ts
+++ b/src/lib/GolemFirstPersonHands.ts
@@ -1,0 +1,237 @@
+import * as THREE from 'three';
+
+/**
+ * First-person viewmodel for Golem possession mode.
+ * Shows two large rocky hands with crystal accents.
+ */
+
+export interface GolemHandsConfig {
+  leftOffset: THREE.Vector3;
+  rightOffset: THREE.Vector3;
+  swayIntensity: number;
+  bobIntensity: number;
+}
+
+export const DEFAULT_GOLEM_HANDS_CONFIG: GolemHandsConfig = {
+  // Hands positioned lower-left and lower-right of view
+  leftOffset: new THREE.Vector3(-0.6, -0.6, -0.8),
+  rightOffset: new THREE.Vector3(0.6, -0.6, -0.8),
+  swayIntensity: 0.08, // Less sway - heavy hands
+  bobIntensity: 0.1,   // More bob - stompy movement
+};
+
+// Golem color palette (same as GolemEntity)
+const GOLEM_COLORS = {
+  rockBase: 0x5c5247,
+  rockDark: 0x4a433b,
+  rockLight: 0x6e6459,
+  crystalOrange: 0xff6b35,
+  crystalBlue: 0x4da6ff,
+};
+
+export class GolemFirstPersonHands {
+  private config: GolemHandsConfig;
+  private group: THREE.Group;
+  private leftHand: THREE.Group;
+  private rightHand: THREE.Group;
+
+  // Animation state
+  private targetSwayX: number = 0;
+  private targetSwayY: number = 0;
+  private currentSwayX: number = 0;
+  private currentSwayY: number = 0;
+  private bobPhase: number = 0;
+  private bobAmount: number = 0;
+  private isMoving: boolean = false;
+
+  constructor(config: Partial<GolemHandsConfig> = {}) {
+    this.config = {
+      ...DEFAULT_GOLEM_HANDS_CONFIG,
+      ...config,
+      leftOffset: config.leftOffset || DEFAULT_GOLEM_HANDS_CONFIG.leftOffset.clone(),
+      rightOffset: config.rightOffset || DEFAULT_GOLEM_HANDS_CONFIG.rightOffset.clone(),
+    };
+
+    this.group = new THREE.Group();
+
+    // Create left hand
+    this.leftHand = this.createHand('left');
+    this.leftHand.position.copy(this.config.leftOffset);
+    this.leftHand.rotation.set(0.3, 0.4, 0.2); // Angled inward
+    this.group.add(this.leftHand);
+
+    // Create right hand
+    this.rightHand = this.createHand('right');
+    this.rightHand.position.copy(this.config.rightOffset);
+    this.rightHand.rotation.set(0.3, -0.4, -0.2); // Angled inward (mirrored)
+    this.group.add(this.rightHand);
+  }
+
+  private createHand(side: 'left' | 'right'): THREE.Group {
+    const hand = new THREE.Group();
+    const mirror = side === 'right' ? -1 : 1;
+
+    // Rock material with flat shading for angular look
+    const rockMaterial = new THREE.MeshStandardMaterial({
+      color: GOLEM_COLORS.rockBase,
+      roughness: 0.95,
+      metalness: 0.1,
+      flatShading: true,
+    });
+
+    const rockDarkMaterial = new THREE.MeshStandardMaterial({
+      color: GOLEM_COLORS.rockDark,
+      roughness: 0.95,
+      metalness: 0.1,
+      flatShading: true,
+    });
+
+    // Main palm - chunky box
+    const palmGeometry = new THREE.BoxGeometry(0.25, 0.18, 0.12);
+    // Slightly randomize vertices for organic rock feel
+    const positions = palmGeometry.attributes.position;
+    for (let i = 0; i < positions.count; i++) {
+      positions.setX(i, positions.getX(i) + (Math.random() - 0.5) * 0.02);
+      positions.setY(i, positions.getY(i) + (Math.random() - 0.5) * 0.02);
+      positions.setZ(i, positions.getZ(i) + (Math.random() - 0.5) * 0.02);
+    }
+    palmGeometry.computeVertexNormals();
+
+    const palm = new THREE.Mesh(palmGeometry, rockMaterial);
+    hand.add(palm);
+
+    // Fingers - three chunky stone digits
+    const fingerPositions = [
+      { x: 0.08 * mirror, y: -0.03, length: 0.15 },
+      { x: 0, y: -0.05, length: 0.17 },
+      { x: -0.08 * mirror, y: -0.03, length: 0.13 },
+    ];
+
+    fingerPositions.forEach((pos, i) => {
+      const fingerGeo = new THREE.BoxGeometry(0.05, pos.length, 0.05);
+      const finger = new THREE.Mesh(fingerGeo, i === 1 ? rockMaterial : rockDarkMaterial);
+      finger.position.set(pos.x, pos.y - pos.length / 2, 0.06);
+      finger.rotation.x = 0.3; // Slightly curled
+      hand.add(finger);
+    });
+
+    // Thumb - positioned on the side
+    const thumbGeo = new THREE.BoxGeometry(0.04, 0.1, 0.04);
+    const thumb = new THREE.Mesh(thumbGeo, rockDarkMaterial);
+    thumb.position.set(0.12 * mirror, 0, 0.04);
+    thumb.rotation.z = -0.5 * mirror;
+    thumb.rotation.x = 0.2;
+    hand.add(thumb);
+
+    // Crystal accent on knuckles
+    const crystalColor = side === 'left' ? GOLEM_COLORS.crystalBlue : GOLEM_COLORS.crystalOrange;
+    const crystalMaterial = new THREE.MeshStandardMaterial({
+      color: crystalColor,
+      emissive: crystalColor,
+      emissiveIntensity: 0.4,
+      roughness: 0.3,
+      metalness: 0.2,
+    });
+
+    const crystalGeo = new THREE.OctahedronGeometry(0.03, 0);
+    const crystal = new THREE.Mesh(crystalGeo, crystalMaterial);
+    crystal.position.set(0, 0.08, 0.07);
+    crystal.rotation.set(0.3, 0.5, 0);
+    hand.add(crystal);
+
+    // Add a small point light from the crystal
+    const crystalLight = new THREE.PointLight(crystalColor, 0.3, 1);
+    crystalLight.position.copy(crystal.position);
+    hand.add(crystalLight);
+
+    return hand;
+  }
+
+  /**
+   * Get the Three.js object to add to camera
+   */
+  getObject(): THREE.Group {
+    return this.group;
+  }
+
+  /**
+   * Set visibility
+   */
+  setVisible(visible: boolean): void {
+    this.group.visible = visible;
+  }
+
+  /**
+   * Set sway from mouse movement
+   */
+  setSway(deltaX: number, deltaY: number): void {
+    this.targetSwayX = -deltaX * 0.001 * this.config.swayIntensity;
+    this.targetSwayY = -deltaY * 0.001 * this.config.swayIntensity;
+  }
+
+  /**
+   * Set bobbing state from movement
+   */
+  setBobbing(isMoving: boolean, speed: number = 1): void {
+    this.isMoving = isMoving;
+    this.bobAmount = isMoving ? Math.min(speed / 3, 1) : 0;
+  }
+
+  /**
+   * Sync step phase from golem camera controller
+   */
+  setStepPhase(phase: number): void {
+    this.bobPhase = phase * Math.PI * 2;
+  }
+
+  /**
+   * Update animation each frame
+   */
+  update(deltaTime: number, elapsedTime: number): void {
+    // Smooth sway interpolation (slower for heavy hands)
+    this.currentSwayX = THREE.MathUtils.lerp(this.currentSwayX, this.targetSwayX, deltaTime * 4);
+    this.currentSwayY = THREE.MathUtils.lerp(this.currentSwayY, this.targetSwayY, deltaTime * 4);
+
+    // Decay target sway
+    this.targetSwayX *= 0.9;
+    this.targetSwayY *= 0.9;
+
+    // Update bob phase when moving
+    if (this.isMoving) {
+      // Bob is synced externally via setStepPhase, but add some continuous motion
+      this.bobPhase += deltaTime * 3;
+    }
+
+    // Calculate bob offset (heavier, more pronounced)
+    const bobY = Math.sin(this.bobPhase) * this.config.bobIntensity * this.bobAmount;
+    const bobX = Math.cos(this.bobPhase * 0.5) * this.config.bobIntensity * 0.3 * this.bobAmount;
+
+    // Apply to left hand
+    this.leftHand.position.x = this.config.leftOffset.x + this.currentSwayX + bobX;
+    this.leftHand.position.y = this.config.leftOffset.y + this.currentSwayY + bobY;
+
+    // Apply to right hand (opposite phase for alternating movement)
+    this.rightHand.position.x = this.config.rightOffset.x + this.currentSwayX - bobX;
+    this.rightHand.position.y = this.config.rightOffset.y + this.currentSwayY - bobY;
+
+    // Subtle rotation sway
+    this.leftHand.rotation.z = 0.2 + this.currentSwayX * 2 + bobX * 0.5;
+    this.rightHand.rotation.z = -0.2 + this.currentSwayX * 2 - bobX * 0.5;
+  }
+
+  /**
+   * Dispose of resources
+   */
+  dispose(): void {
+    this.group.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose();
+        if (Array.isArray(child.material)) {
+          child.material.forEach((m) => m.dispose());
+        } else {
+          child.material.dispose();
+        }
+      }
+    });
+  }
+}

--- a/src/lib/camera/GolemCameraController.ts
+++ b/src/lib/camera/GolemCameraController.ts
@@ -1,0 +1,299 @@
+import * as THREE from 'three';
+
+/**
+ * First-person camera controller for Golem possession mode.
+ * Features heavy stompy camera movement with exaggerated bob and screen shake.
+ */
+
+export interface GolemCameraConfig {
+  eyeHeight: number;          // Camera height (much higher for golem)
+  moveSpeed: number;          // Movement speed (slower for heavy creature)
+  mouseSensitivity: number;   // Look sensitivity
+
+  // Stompy effects
+  stompBobIntensity: number;  // Vertical bob amplitude
+  stompBobFrequency: number;  // Steps per second
+  screenShakeIntensity: number; // Shake intensity on step impact
+  screenShakeDecay: number;   // How fast shake decays (0-1)
+  stepDuration: number;       // Time per step in seconds
+}
+
+export const DEFAULT_GOLEM_CAMERA_CONFIG: GolemCameraConfig = {
+  eyeHeight: 8.0,             // Much higher than normal (1.6)
+  moveSpeed: 3.0,             // Slower than normal (5.0)
+  mouseSensitivity: 0.002,
+
+  // Stompy effects
+  stompBobIntensity: 0.25,    // Exaggerated vertical bob
+  stompBobFrequency: 1.2,     // Slower steps (heavy creature)
+  screenShakeIntensity: 0.025, // Subtle but noticeable shake
+  screenShakeDecay: 0.85,     // Quick falloff
+  stepDuration: 0.6,          // ~1.7 steps per second
+};
+
+interface InputState {
+  forward: boolean;
+  back: boolean;
+  left: boolean;
+  right: boolean;
+}
+
+export class GolemCameraController {
+  private config: GolemCameraConfig;
+
+  // Position and rotation
+  private position: THREE.Vector3;
+  private velocity: THREE.Vector3;
+  private yaw: number;
+  private pitch: number;
+
+  // Input state
+  private keys: InputState;
+  private mouseDeltaAccum: THREE.Vector2;
+
+  // Stomp animation state
+  private stepPhase: number = 0;
+  private screenShake: THREE.Vector3;
+  private lastStepImpact: number = 0; // Time of last step impact for shake
+
+  // Camera reference
+  private camera: THREE.PerspectiveCamera | null = null;
+
+  constructor(config: Partial<GolemCameraConfig> = {}) {
+    this.config = { ...DEFAULT_GOLEM_CAMERA_CONFIG, ...config };
+
+    this.position = new THREE.Vector3();
+    this.velocity = new THREE.Vector3();
+    this.yaw = 0;
+    this.pitch = 0;
+
+    this.keys = {
+      forward: false,
+      back: false,
+      left: false,
+      right: false,
+    };
+
+    this.mouseDeltaAccum = new THREE.Vector2();
+    this.screenShake = new THREE.Vector3();
+  }
+
+  setCamera(camera: THREE.PerspectiveCamera): void {
+    this.camera = camera;
+  }
+
+  /**
+   * Initialize position from golem world position
+   */
+  setPosition(golemPosition: THREE.Vector3): void {
+    this.position.set(
+      golemPosition.x,
+      golemPosition.y + this.config.eyeHeight,
+      golemPosition.z
+    );
+    this.velocity.set(0, 0, 0);
+  }
+
+  /**
+   * Set initial yaw (facing direction)
+   */
+  setYaw(yaw: number): void {
+    this.yaw = yaw;
+    this.pitch = 0;
+  }
+
+  getPosition(): THREE.Vector3 {
+    return this.position.clone();
+  }
+
+  getGroundPosition(): THREE.Vector3 {
+    const ground = this.position.clone();
+    ground.y -= this.config.eyeHeight;
+    return ground;
+  }
+
+  isMoving(): boolean {
+    return this.velocity.lengthSq() > 0.1;
+  }
+
+  handleKeyDown(event: KeyboardEvent): void {
+    const code = event.code;
+
+    if (code === 'KeyW' || code === 'ArrowUp') this.keys.forward = true;
+    if (code === 'KeyS' || code === 'ArrowDown') this.keys.back = true;
+    if (code === 'KeyA' || code === 'ArrowLeft') this.keys.left = true;
+    if (code === 'KeyD' || code === 'ArrowRight') this.keys.right = true;
+  }
+
+  handleKeyUp(event: KeyboardEvent): void {
+    const code = event.code;
+
+    if (code === 'KeyW' || code === 'ArrowUp') this.keys.forward = false;
+    if (code === 'KeyS' || code === 'ArrowDown') this.keys.back = false;
+    if (code === 'KeyA' || code === 'ArrowLeft') this.keys.left = false;
+    if (code === 'KeyD' || code === 'ArrowRight') this.keys.right = false;
+  }
+
+  handleMouseMove(event: MouseEvent): void {
+    this.mouseDeltaAccum.x += event.movementX;
+    this.mouseDeltaAccum.y += event.movementY;
+  }
+
+  resetInput(): void {
+    this.keys.forward = false;
+    this.keys.back = false;
+    this.keys.left = false;
+    this.keys.right = false;
+    this.mouseDeltaAccum.set(0, 0);
+    this.velocity.set(0, 0, 0);
+    this.stepPhase = 0;
+    this.screenShake.set(0, 0, 0);
+  }
+
+  /**
+   * Update controller state each frame
+   */
+  update(deltaTime: number, elapsedTime: number): void {
+    // Apply mouse rotation
+    this.yaw -= this.mouseDeltaAccum.x * this.config.mouseSensitivity;
+    this.pitch -= this.mouseDeltaAccum.y * this.config.mouseSensitivity;
+    this.mouseDeltaAccum.set(0, 0);
+
+    // Clamp pitch
+    this.pitch = THREE.MathUtils.clamp(this.pitch, -Math.PI * 0.45, Math.PI * 0.45);
+
+    // Calculate movement direction
+    const inputDir = new THREE.Vector3();
+    if (this.keys.forward) inputDir.z -= 1;
+    if (this.keys.back) inputDir.z += 1;
+    if (this.keys.left) inputDir.x -= 1;
+    if (this.keys.right) inputDir.x += 1;
+
+    if (inputDir.lengthSq() > 0) {
+      inputDir.normalize();
+    }
+
+    // Rotate by yaw
+    const cosYaw = Math.cos(this.yaw);
+    const sinYaw = Math.sin(this.yaw);
+    const worldDir = new THREE.Vector3(
+      inputDir.x * cosYaw + inputDir.z * sinYaw,
+      0,
+      -inputDir.x * sinYaw + inputDir.z * cosYaw
+    );
+
+    // Calculate velocity (slower acceleration for heavy golem)
+    const targetVelocity = worldDir.multiplyScalar(this.config.moveSpeed);
+
+    if (worldDir.lengthSq() > 0) {
+      // Slower acceleration - heavy creature
+      this.velocity.lerp(targetVelocity, 1 - Math.exp(-5 * deltaTime));
+    } else {
+      // Slower deceleration - momentum
+      this.velocity.lerp(new THREE.Vector3(), 1 - Math.exp(-3 * deltaTime));
+    }
+
+    // Update position
+    const movement = this.velocity.clone().multiplyScalar(deltaTime);
+    this.position.add(movement);
+
+    // Keep at ground level + eye height (simplified - no terrain following for now)
+    // In a real implementation, you'd want to check terrain height here
+    this.position.y = this.config.eyeHeight;
+
+    // Update stomp animation when moving
+    const speed = this.velocity.length();
+    if (speed > 0.5) {
+      // Advance step phase based on movement speed
+      const previousPhase = this.stepPhase;
+      this.stepPhase += deltaTime * this.config.stompBobFrequency;
+      this.stepPhase %= 1;
+
+      // Detect step impact (phase crossing 0 or 0.5)
+      const crossedZero = previousPhase > 0.9 && this.stepPhase < 0.1;
+      const crossedHalf = previousPhase < 0.5 && this.stepPhase >= 0.5;
+
+      if (crossedZero || crossedHalf) {
+        // Trigger screen shake on step impact
+        this.triggerStepShake();
+      }
+    } else {
+      // Smoothly reset phase when stopped
+      this.stepPhase = THREE.MathUtils.lerp(this.stepPhase, 0, deltaTime * 3);
+    }
+
+    // Decay screen shake
+    this.screenShake.multiplyScalar(this.config.screenShakeDecay);
+
+    // Update camera
+    if (this.camera) {
+      this.updateCamera(speed);
+    }
+  }
+
+  /**
+   * Trigger screen shake effect on step impact
+   */
+  private triggerStepShake(): void {
+    // Add random shake impulse
+    this.screenShake.x += (Math.random() - 0.5) * this.config.screenShakeIntensity;
+    this.screenShake.y += Math.random() * this.config.screenShakeIntensity * 0.5; // Mostly downward
+    this.screenShake.z += (Math.random() - 0.5) * this.config.screenShakeIntensity;
+  }
+
+  /**
+   * Update camera with stompy effects
+   */
+  private updateCamera(speed: number): void {
+    if (!this.camera) return;
+
+    // Base position
+    this.camera.position.copy(this.position);
+
+    // Apply stompy vertical bob when moving
+    if (speed > 0.5) {
+      // Sine wave bob synced to step phase
+      const bobOffset = Math.sin(this.stepPhase * Math.PI * 2) * this.config.stompBobIntensity;
+      this.camera.position.y += bobOffset;
+
+      // Slight side-to-side sway (like a heavy creature shifting weight)
+      const swayOffset = Math.sin(this.stepPhase * Math.PI) * 0.1;
+      this.camera.position.x += swayOffset * Math.cos(this.yaw);
+      this.camera.position.z += swayOffset * Math.sin(this.yaw);
+    }
+
+    // Apply screen shake
+    this.camera.position.add(this.screenShake);
+
+    // Set rotation
+    const euler = new THREE.Euler(
+      this.pitch + this.screenShake.y * 2, // Shake affects pitch
+      this.yaw,
+      this.screenShake.x * 2, // Shake affects roll
+      'YXZ'
+    );
+    this.camera.quaternion.setFromEuler(euler);
+  }
+
+  /**
+   * Get hand sway for viewmodel animation
+   */
+  getHandSway(): THREE.Vector2 {
+    const speed = this.velocity.length();
+
+    // More pronounced sway when stomping
+    const bobSway = speed > 0.5 ? Math.sin(this.stepPhase * Math.PI * 2) * 0.1 : 0;
+
+    return new THREE.Vector2(
+      this.screenShake.x + bobSway,
+      this.screenShake.y + Math.abs(bobSway) * 0.5
+    );
+  }
+
+  /**
+   * Get current step phase for hand animation sync
+   */
+  getStepPhase(): number {
+    return this.stepPhase;
+  }
+}

--- a/src/lib/camera/index.ts
+++ b/src/lib/camera/index.ts
@@ -6,3 +6,6 @@ export type { SpringArmConfig } from './SpringArm';
 
 export { FirstPersonController, DEFAULT_FIRST_PERSON_CONFIG } from './FirstPersonController';
 export type { FirstPersonConfig } from './FirstPersonController';
+
+export { GolemCameraController, DEFAULT_GOLEM_CAMERA_CONFIG } from './GolemCameraController';
+export type { GolemCameraConfig } from './GolemCameraController';

--- a/src/lib/golem/index.ts
+++ b/src/lib/golem/index.ts
@@ -1,0 +1,291 @@
+import * as THREE from 'three';
+
+// Golem is 5x larger than minions (minion scale is 0.5, so golem is 2.5)
+const GOLEM_SCALE = 2.5;
+
+// Golem color palette - rocky with crystal accents
+const GOLEM_COLORS = {
+  rockBase: 0x5c5247,
+  rockDark: 0x4a433b,
+  rockLight: 0x6e6459,
+  crystalOrange: 0xff6b35,
+  crystalBlue: 0x4da6ff,
+  eyeCore: 0xff6b35,
+};
+
+// Deterministic pseudo-random for consistent geometry
+function seededRandom(seed: number): number {
+  const x = Math.sin(seed * 12.9898 + seed * 78.233) * 43758.5453;
+  return x - Math.floor(x) - 0.5;
+}
+
+export interface GolemInstance {
+  mesh: THREE.Group;
+  leftHand: THREE.Group;
+  rightHand: THREE.Group;
+  leftLeg: THREE.Group;
+  rightLeg: THREE.Group;
+  eyeLight: THREE.PointLight;
+  dispose: () => void;
+}
+
+/**
+ * Creates a vanilla Three.js golem mesh - a large rocky creature with crystal accents
+ */
+export function createGolem(): GolemInstance {
+  const group = new THREE.Group();
+  group.scale.setScalar(GOLEM_SCALE);
+
+  // Materials
+  const rockMaterial = new THREE.MeshStandardMaterial({
+    color: GOLEM_COLORS.rockBase,
+    roughness: 0.95,
+    metalness: 0.1,
+    flatShading: true,
+  });
+
+  const rockDarkMaterial = new THREE.MeshStandardMaterial({
+    color: GOLEM_COLORS.rockDark,
+    roughness: 0.95,
+    metalness: 0.1,
+    flatShading: true,
+  });
+
+  const crystalOrangeMaterial = new THREE.MeshStandardMaterial({
+    color: GOLEM_COLORS.crystalOrange,
+    emissive: GOLEM_COLORS.crystalOrange,
+    emissiveIntensity: 0.5,
+    roughness: 0.3,
+    metalness: 0.2,
+  });
+
+  const crystalBlueMaterial = new THREE.MeshStandardMaterial({
+    color: GOLEM_COLORS.crystalBlue,
+    emissive: GOLEM_COLORS.crystalBlue,
+    emissiveIntensity: 0.4,
+    roughness: 0.3,
+    metalness: 0.2,
+  });
+
+  // === TORSO (massive, rocky) ===
+  const torsoGeometry = new THREE.BoxGeometry(1.2, 1.6, 0.8, 2, 2, 2);
+  const torsoPositions = torsoGeometry.attributes.position;
+  for (let i = 0; i < torsoPositions.count; i++) {
+    torsoPositions.setX(i, torsoPositions.getX(i) + seededRandom(i * 3) * 0.08);
+    torsoPositions.setY(i, torsoPositions.getY(i) + seededRandom(i * 3 + 1) * 0.08);
+    torsoPositions.setZ(i, torsoPositions.getZ(i) + seededRandom(i * 3 + 2) * 0.08);
+  }
+  torsoGeometry.computeVertexNormals();
+  const torso = new THREE.Mesh(torsoGeometry, rockMaterial);
+  torso.position.y = 0.8;
+  torso.castShadow = true;
+  group.add(torso);
+
+  // Crystal embedded in chest
+  const chestCrystal = new THREE.Mesh(
+    new THREE.OctahedronGeometry(0.15, 0),
+    crystalOrangeMaterial
+  );
+  chestCrystal.position.set(0, 0.7, 0.45);
+  chestCrystal.rotation.set(0.3, 0.5, 0);
+  chestCrystal.castShadow = true;
+  group.add(chestCrystal);
+
+  // === HEAD (tiny ball on massive torso) ===
+  const headGeometry = new THREE.SphereGeometry(0.2, 6, 6);
+  const head = new THREE.Mesh(headGeometry, rockDarkMaterial);
+  head.position.set(0, 1.8, 0);
+  head.castShadow = true;
+  group.add(head);
+
+  // Eye (crystal)
+  const eye = new THREE.Mesh(
+    new THREE.SphereGeometry(0.08, 8, 8),
+    crystalOrangeMaterial
+  );
+  eye.position.set(0, 1.85, 0.15);
+  group.add(eye);
+
+  // Eye glow light
+  const eyeLight = new THREE.PointLight(GOLEM_COLORS.eyeCore, 1, 3);
+  eyeLight.position.copy(eye.position);
+  group.add(eyeLight);
+
+  // === FLOATING HANDS (chunky rock fists) ===
+  function createHand(isLeft: boolean): THREE.Group {
+    const hand = new THREE.Group();
+    const xOffset = isLeft ? -1.0 : 1.0;
+
+    // Main fist
+    const fistGeo = new THREE.BoxGeometry(0.35, 0.3, 0.25, 2, 2, 2);
+    const fistPositions = fistGeo.attributes.position;
+    for (let i = 0; i < fistPositions.count; i++) {
+      fistPositions.setX(i, fistPositions.getX(i) + seededRandom(i * 5 + (isLeft ? 0 : 100)) * 0.03);
+      fistPositions.setY(i, fistPositions.getY(i) + seededRandom(i * 5 + 1 + (isLeft ? 0 : 100)) * 0.03);
+      fistPositions.setZ(i, fistPositions.getZ(i) + seededRandom(i * 5 + 2 + (isLeft ? 0 : 100)) * 0.03);
+    }
+    fistGeo.computeVertexNormals();
+    const fist = new THREE.Mesh(fistGeo, rockMaterial);
+    fist.castShadow = true;
+    hand.add(fist);
+
+    // Finger bumps (3 knuckle-like protrusions)
+    for (let i = 0; i < 3; i++) {
+      const knuckle = new THREE.Mesh(
+        new THREE.BoxGeometry(0.08, 0.15, 0.08),
+        rockDarkMaterial
+      );
+      knuckle.position.set((i - 1) * 0.1, -0.15, 0.1);
+      knuckle.castShadow = true;
+      hand.add(knuckle);
+    }
+
+    // Crystal accent
+    const handCrystal = new THREE.Mesh(
+      new THREE.OctahedronGeometry(0.05, 0),
+      isLeft ? crystalBlueMaterial : crystalOrangeMaterial
+    );
+    handCrystal.position.set(0, 0.12, 0.1);
+    handCrystal.rotation.set(0.3, 0.5, 0);
+    hand.add(handCrystal);
+
+    hand.position.set(xOffset, 0.5, 0.2);
+    return hand;
+  }
+
+  const leftHand = createHand(true);
+  const rightHand = createHand(false);
+  group.add(leftHand);
+  group.add(rightHand);
+
+  // === STUMP LEGS (short rocky pillars) ===
+  function createLeg(isLeft: boolean): THREE.Group {
+    const leg = new THREE.Group();
+    const xOffset = isLeft ? -0.35 : 0.35;
+
+    const legGeo = new THREE.CylinderGeometry(0.2, 0.25, 0.5, 6);
+    const legMesh = new THREE.Mesh(legGeo, rockDarkMaterial);
+    legMesh.castShadow = true;
+    leg.add(legMesh);
+
+    // Foot (wider base)
+    const foot = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.25, 0.3, 0.15, 6),
+      rockMaterial
+    );
+    foot.position.y = -0.3;
+    foot.castShadow = true;
+    leg.add(foot);
+
+    leg.position.set(xOffset, -0.2, 0);
+    return leg;
+  }
+
+  const leftLeg = createLeg(true);
+  const rightLeg = createLeg(false);
+  group.add(leftLeg);
+  group.add(rightLeg);
+
+  // === SHOULDER CRYSTALS ===
+  const leftShoulderCrystal = new THREE.Mesh(
+    new THREE.OctahedronGeometry(0.1, 0),
+    crystalBlueMaterial
+  );
+  leftShoulderCrystal.position.set(-0.7, 1.3, 0);
+  leftShoulderCrystal.rotation.set(0.5, 0.3, 0.2);
+  group.add(leftShoulderCrystal);
+
+  const rightShoulderCrystal = new THREE.Mesh(
+    new THREE.OctahedronGeometry(0.12, 0),
+    crystalOrangeMaterial
+  );
+  rightShoulderCrystal.position.set(0.7, 1.4, 0.1);
+  rightShoulderCrystal.rotation.set(0.3, -0.5, -0.2);
+  group.add(rightShoulderCrystal);
+
+  // Disposal function
+  const dispose = () => {
+    group.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose();
+        if (Array.isArray(child.material)) {
+          child.material.forEach((m) => m.dispose());
+        } else {
+          child.material.dispose();
+        }
+      }
+    });
+  };
+
+  return {
+    mesh: group,
+    leftHand,
+    rightHand,
+    leftLeg,
+    rightLeg,
+    eyeLight,
+    dispose,
+  };
+}
+
+/**
+ * Update golem animation based on state
+ */
+export function updateGolemAnimation(
+  instance: GolemInstance,
+  state: 'idle' | 'traveling' | 'stomping',
+  time: number,
+  baseY: number
+): void {
+  const { mesh, leftHand, rightHand, leftLeg, rightLeg, eyeLight } = instance;
+
+  switch (state) {
+    case 'idle':
+      // Very subtle breathing motion
+      mesh.position.y = baseY + Math.sin(time * 0.8) * 0.02 * GOLEM_SCALE;
+
+      // Floating hands gentle bob
+      leftHand.position.y = 0.5 + Math.sin(time * 1.2) * 0.05;
+      rightHand.position.y = 0.5 + Math.sin(time * 1.2 + Math.PI) * 0.05;
+
+      // Eye glow pulse
+      eyeLight.intensity = 0.8 + Math.sin(time * 2) * 0.3;
+      break;
+
+    case 'traveling':
+      const walkCycle = time * 2;
+      const stomp = Math.abs(Math.sin(walkCycle)) * 0.08 * GOLEM_SCALE;
+      mesh.position.y = baseY + stomp;
+
+      // Heavy body sway
+      mesh.rotation.z = Math.sin(walkCycle) * 0.03;
+
+      // Leg movement
+      leftLeg.position.y = -0.2 + Math.max(0, Math.sin(walkCycle)) * 0.15;
+      rightLeg.position.y = -0.2 + Math.max(0, Math.sin(walkCycle + Math.PI)) * 0.15;
+
+      // Floating hands swing
+      leftHand.position.y = 0.5 + Math.sin(walkCycle) * 0.1;
+      leftHand.position.z = 0.2 + Math.sin(walkCycle) * 0.15;
+      rightHand.position.y = 0.5 + Math.sin(walkCycle + Math.PI) * 0.1;
+      rightHand.position.z = 0.2 + Math.sin(walkCycle + Math.PI) * 0.15;
+
+      // Eye intensifies
+      eyeLight.intensity = 1.2 + Math.sin(time * 3) * 0.2;
+      break;
+
+    case 'stomping':
+      const stompCycle = time * 4;
+      const pound = Math.abs(Math.sin(stompCycle)) * 0.15 * GOLEM_SCALE;
+      mesh.position.y = baseY + pound;
+
+      // Hands slam
+      const armSlam = Math.sin(stompCycle) > 0 ? 0.2 : 0.6;
+      leftHand.position.y = armSlam;
+      rightHand.position.y = armSlam;
+
+      // Eye flares
+      eyeLight.intensity = 1.5 + Math.abs(Math.sin(stompCycle)) * 0.5;
+      break;
+  }
+}

--- a/src/lib/interaction/StaffInteractionController.ts
+++ b/src/lib/interaction/StaffInteractionController.ts
@@ -34,6 +34,7 @@ interface StaffInteractionCallbacks {
   onModeChange?: (mode: InteractionMode) => void;
   onStaffStateChange?: (state: StaffState) => void;
   onEntityThrown?: (thrown: ThrownEntity) => void;
+  onSpawnGolem?: (position: { x: number; y: number; z: number }) => void;
 }
 
 export class StaffInteractionController {
@@ -519,6 +520,13 @@ export class StaffInteractionController {
           this.foundationDrawer.startDrawing(target.position);
           this.setMode('drawing');
           return; // Don't set to idle
+        }
+        break;
+
+      case 'spawn_golem':
+        if (target?.type === 'ground') {
+          const pos = target.position;
+          this.callbacks.onSpawnGolem?.({ x: pos.x, y: pos.y, z: pos.z });
         }
         break;
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -3,6 +3,18 @@
 export type MinionRole = 'scout' | 'scribe' | 'artificer';
 export type MinionState = 'idle' | 'traveling' | 'working' | 'stuck' | 'returning' | 'conversing';
 
+// Golem types (independent of minion system)
+export type GolemState = 'idle' | 'traveling' | 'stomping';
+
+export interface Golem {
+  id: string;
+  name: string;
+  position: { x: number; y: number; z: number };
+  state: GolemState;
+  targetPosition?: { x: number; y: number; z: number };
+  createdAt: number;
+}
+
 // Minion personality types for conversation reactions
 export type MinionPersonality = 'friendly' | 'cautious' | 'grumpy';
 
@@ -114,6 +126,7 @@ export interface GameState {
   tower: Tower;
   wizard: Wizard;
   minions: Minion[];
+  golems: Golem[];
   quests: Quest[];
   artifacts: Artifact[];
   postcards: Postcard[];

--- a/src/types/interaction.ts
+++ b/src/types/interaction.ts
@@ -61,6 +61,7 @@ export const BUILDING_MENU_OPTIONS: MenuOption[] = [
 
 export const GROUND_MENU_OPTIONS: MenuOption[] = [
   { id: 'build', label: 'New Building', icon: '🏗️', description: 'Draw foundation' },
+  { id: 'spawn_golem', label: 'Summon Golem', icon: '🗿', description: 'Summon a golem here' },
   { id: 'cancel', label: 'Cancel', icon: '✕', description: 'Close menu' },
 ];
 


### PR DESCRIPTION
- Add Golem type and state management to game store
- Create GolemEntity React component for VillageScene
- Create vanilla Three.js golem factory (lib/golem)
- Add GolemCameraController for stompy first-person mode
- Add GolemFirstPersonHands viewmodel with crystal accents
- Integrate golem rendering in SimpleScene
- Add "Summon Golem" option to ground radial menu
- Update FirstPersonHUD for golem possession mode
- Golems are 5x larger than minions with rocky texture
- Features orange/blue crystal accents and glowing eye